### PR TITLE
reworded how to install themes after trying repeatedly to install a theme by dragging it from my browser window onto Dotgrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ The Theme file format is a SVG file. The [theme.js](https://github.com/hundredra
 </svg>
 ```
 
-## Collection
+## Installation
 
-Simply **drag and drop these images onto the application window**, from your desktop, to install them.
+Simply download these SVG files, and **drag and drop them onto the application window**, to install them.
 
 ### Dark
 


### PR DESCRIPTION
also changed the header from Collection to Installation, though I guess its a collection of installable themes installation instructions are pretty important to have a header for. 