### PR TITLE
Publish to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@hundredrabbits/themes",
+  "version": "1.0.0",
+  "description": "Simple Theme Framework",
+  "main": "scripts/lib/theme.js",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hundredrabbits/Themes.git"
+  },
+  "author": "hundredrabbits",
+  "license": "UNLICENSED",
+  "bugs": {
+    "url": "https://github.com/hundredrabbits/Themes/issues"
+  },
+  "homepage": "https://github.com/hundredrabbits/Themes#readme"
+}


### PR DESCRIPTION
To publish this package, just create an account on https://npmjs.com and run `npm publish --access public`.
Also, maybe consider adding a license?