### PR TITLE
Add a preview page generator

### DIFF
--- a/.github/workflows/create-preview-page.py
+++ b/.github/workflows/create-preview-page.py
@@ -1,0 +1,37 @@
+"""
+Creates a preview page for all SVGs in /themes/*.svg, of the form:
+
+|   |   |   |  |
+|---|---|---|---|
+| ![](example.svg) [Theme Name](Theme Link) | ...
+
+etc
+"""
+
+import pathlib
+
+COLUMN_COUNT = 4
+OUT_PATH = "PREVIEW.md"
+
+
+def main():
+    themes = pathlib.Path("themes")
+    theme_files = themes.glob("*.svg")
+    theme_names = [theme.stem for theme in theme_files]
+    theme_names.sort()
+
+    with open(OUT_PATH, "w") as readme:
+        readme.write("# Theme Previews\n\n")
+        readme.write("|   |   |   |  |\n")
+        readme.write("|---|---|---|---|\n")
+        for i in range(0, len(theme_names), COLUMN_COUNT):
+            row = theme_names[i : i + COLUMN_COUNT]
+            row = [
+                f"![]({themes / (theme + '.svg')}) <br />**[{theme}]({themes / (theme + '.svg')})**"
+                for theme in row
+            ]
+            readme.write("| " + " | ".join(row) + " |\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -1,0 +1,25 @@
+# A GitHub action to create a "PREVIEWS.md" file automatically with
+# a table of all of the themes from /themes/*.svg, sorted by name.
+
+name: Create-Preview
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        # Call .github/workflows/create-preview-page.py
+      - name: Create Preview
+        run: python3 .github/workflows/create-preview-page.py
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v4
+        with:
+          message: "Update PREVIEWS.md"
+          add: "PREVIEWS.md"
+
+          

--- a/PREVIEW.md
+++ b/PREVIEW.md
@@ -1,0 +1,16 @@
+# Themes
+
+|   |   |   |  |
+|---|---|---|---|
+| ![](themes/apollo.svg) <br />**[apollo](themes/apollo.svg)** | ![](themes/battlestation.svg) <br />**[battlestation](themes/battlestation.svg)** | ![](themes/berry.svg) <br />**[berry](themes/berry.svg)** | ![](themes/bigtime.svg) <br />**[bigtime](themes/bigtime.svg)** |
+| ![](themes/boysenberry.svg) <br />**[boysenberry](themes/boysenberry.svg)** | ![](themes/coal.svg) <br />**[coal](themes/coal.svg)** | ![](themes/cobalt.svg) <br />**[cobalt](themes/cobalt.svg)** | ![](themes/commodore.svg) <br />**[commodore](themes/commodore.svg)** |
+| ![](themes/forestlawn.svg) <br />**[forestlawn](themes/forestlawn.svg)** | ![](themes/frameio.svg) <br />**[frameio](themes/frameio.svg)** | ![](themes/gameboy.svg) <br />**[gameboy](themes/gameboy.svg)** | ![](themes/garden.svg) <br />**[garden](themes/garden.svg)** |
+| ![](themes/gotham.svg) <br />**[gotham](themes/gotham.svg)** | ![](themes/haxe.svg) <br />**[haxe](themes/haxe.svg)** | ![](themes/isotope.svg) <br />**[isotope](themes/isotope.svg)** | ![](themes/kawaii.svg) <br />**[kawaii](themes/kawaii.svg)** |
+| ![](themes/laundry.svg) <br />**[laundry](themes/laundry.svg)** | ![](themes/lotus.svg) <br />**[lotus](themes/lotus.svg)** | ![](themes/mahou.svg) <br />**[mahou](themes/mahou.svg)** | ![](themes/marble.svg) <br />**[marble](themes/marble.svg)** |
+| ![](themes/murata.svg) <br />**[murata](themes/murata.svg)** | ![](themes/muzieca.svg) <br />**[muzieca](themes/muzieca.svg)** | ![](themes/nightowl.svg) <br />**[nightowl](themes/nightowl.svg)** | ![](themes/ninetynine.svg) <br />**[ninetynine](themes/ninetynine.svg)** |
+| ![](themes/noir.svg) <br />**[noir](themes/noir.svg)** | ![](themes/nord.svg) <br />**[nord](themes/nord.svg)** | ![](themes/obsidian.svg) <br />**[obsidian](themes/obsidian.svg)** | ![](themes/op-1.svg) <br />**[op-1](themes/op-1.svg)** |
+| ![](themes/orca.svg) <br />**[orca](themes/orca.svg)** | ![](themes/pawbin.svg) <br />**[pawbin](themes/pawbin.svg)** | ![](themes/pico8.svg) <br />**[pico8](themes/pico8.svg)** | ![](themes/polivoks.svg) <br />**[polivoks](themes/polivoks.svg)** |
+| ![](themes/rainonwires.svg) <br />**[rainonwires](themes/rainonwires.svg)** | ![](themes/roguelight.svg) <br />**[roguelight](themes/roguelight.svg)** | ![](themes/sk.svg) <br />**[sk](themes/sk.svg)** | ![](themes/snow.svg) <br />**[snow](themes/snow.svg)** |
+| ![](themes/solarised.dark.svg) <br />**[solarised.dark](themes/solarised.dark.svg)** | ![](themes/solarised.light.svg) <br />**[solarised.light](themes/solarised.light.svg)** | ![](themes/sonicpi.svg) <br />**[sonicpi](themes/sonicpi.svg)** | ![](themes/soyuz.svg) <br />**[soyuz](themes/soyuz.svg)** |
+| ![](themes/tape.svg) <br />**[tape](themes/tape.svg)** | ![](themes/teenage.svg) <br />**[teenage](themes/teenage.svg)** | ![](themes/teletext.svg) <br />**[teletext](themes/teletext.svg)** | ![](themes/vacuui.svg) <br />**[vacuui](themes/vacuui.svg)** |
+| ![](themes/zenburn.svg) <br />**[zenburn](themes/zenburn.svg)** |


### PR DESCRIPTION
This PR adds a GitHub actions workflow that automatically generates a `PREVIEW.md` (see initial file, checked in!) with links to each theme in `/themes/*.svg`. 

Feel free to close this if you don't like the idea of a bot automatically updating this repo; just thought it might be a useful resource!
